### PR TITLE
feat(file-explorer): Use real filesystem and add nav pane

### DIFF
--- a/function/stable/filesystem/Filesystem_v2_main.ts
+++ b/function/stable/filesystem/Filesystem_v2_main.ts
@@ -1,0 +1,147 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const PROJECT_ROOT = process.cwd();
+
+/**
+ * Validates if a given path is within the project's root directory.
+ * This is a security measure to prevent path traversal attacks.
+ * @param relativePath The path to validate.
+ * @returns The resolved, absolute path if it's safe, or null otherwise.
+ */
+const resolveSafePath = (relativePath: string): string | null => {
+    const fullPath = path.resolve(PROJECT_ROOT, relativePath);
+    if (!fullPath.startsWith(PROJECT_ROOT)) {
+        console.error(`[Security] Path traversal attempt blocked: ${relativePath}`);
+        return null;
+    }
+    return fullPath;
+};
+
+
+export interface FilesystemItem {
+    name: string;
+    path: string;
+    type: 'file' | 'folder';
+}
+
+/**
+ * @description Lists the contents of a directory in the project filesystem.
+ * @param relativePath The path relative to the project root (e.g., "/apps").
+ * @returns An array of filesystem items, or null if the path is invalid or does not exist.
+ */
+export const Filesystem_v2_getItemsInPath = async (relativePath: string): Promise<FilesystemItem[] | null> => {
+    const fullPath = resolveSafePath(relativePath);
+    if (!fullPath) return null;
+
+    try {
+        const items = await fs.readdir(fullPath, { withFileTypes: true });
+        return items.map(item => ({
+            name: item.name,
+            path: path.join(relativePath, item.name),
+            type: item.isDirectory() ? 'folder' : 'file',
+        }));
+    } catch (error) {
+        console.error(`[Filesystem_v2_getItemsInPath] Error listing path ${relativePath}:`, error);
+        return null;
+    }
+};
+
+/**
+ * @description Creates a new folder in the project filesystem.
+ * @param relativePath The path where the new folder should be created.
+ * @param folderName The name of the new folder.
+ * @returns True if successful, false otherwise.
+ */
+export const Filesystem_v2_createFolder = async (relativePath: string, folderName: string): Promise<boolean> => {
+    const fullPath = resolveSafePath(path.join(relativePath, folderName));
+    if (!fullPath) return false;
+
+    try {
+        await fs.mkdir(fullPath);
+        return true;
+    } catch (error) {
+        console.error(`[Filesystem_v2_createFolder] Error creating folder ${folderName} in ${relativePath}:`, error);
+        return false;
+    }
+};
+
+/**
+ * @description Reads and parses a .app file from the filesystem.
+ * @param relativePath The path of the .app file.
+ * @returns The parsed JSON content of the file, or null if an error occurs.
+ */
+export const Filesystem_v2_readAppFile = async (relativePath: string): Promise<any | null> => {
+    const fullPath = resolveSafePath(relativePath);
+    if (!fullPath) return null;
+
+    try {
+        const content = await fs.readFile(fullPath, 'utf-8');
+        return JSON.parse(content);
+    } catch (error) {
+        console.error(`[Filesystem_v2_readAppFile] Error reading or parsing app file ${relativePath}:`, error);
+        return null;
+    }
+};
+
+/**
+ * @description Creates a new, empty text file in the project filesystem.
+ * @param relativePath The path where the new file should be created.
+ * @param fileName The name of the new file.
+ * @returns True if successful, false otherwise.
+ */
+export const Filesystem_v2_createFile = async (relativePath: string, fileName: string): Promise<boolean> => {
+    const fullPath = resolveSafePath(path.join(relativePath, fileName));
+    if (!fullPath) return false;
+
+    try {
+        await fs.writeFile(fullPath, '', 'utf-8');
+        return true;
+    } catch (error) {
+        console.error(`[Filesystem_v2_createFile] Error creating file ${fileName} in ${relativePath}:`, error);
+        return false;
+    }
+};
+
+/**
+ * @description Deletes a file or folder from the project filesystem.
+ * @param relativePath The path of the item to delete.
+ * @returns True if successful, false otherwise.
+ */
+export const Filesystem_v2_deleteItem = async (relativePath: string): Promise<boolean> => {
+    const fullPath = resolveSafePath(relativePath);
+    if (!fullPath) return false;
+
+    try {
+        await fs.rm(fullPath, { recursive: true, force: true });
+        return true;
+    } catch (error) {
+        console.error(`[Filesystem_v2_deleteItem] Error deleting item ${relativePath}:`, error);
+        return false;
+    }
+};
+
+/**
+ * @description Renames a file or folder in the project filesystem.
+ * @param relativePath The current path of the item.
+ * @param newName The new name for the item.
+ * @returns True if successful, false otherwise.
+ */
+export const Filesystem_v2_renameItem = async (relativePath: string, newName: string): Promise<boolean> => {
+    const oldFullPath = resolveSafePath(relativePath);
+    if (!oldFullPath) return false;
+
+    const newFullPath = path.join(path.dirname(oldFullPath), newName);
+    if (!newFullPath.startsWith(PROJECT_ROOT)) {
+        console.error(`[Security] Path traversal attempt blocked during rename: ${newName}`);
+        return false;
+    }
+
+    try {
+        await fs.rename(oldFullPath, newFullPath);
+        return true;
+    } catch (error) {
+        console.error(`[Filesystem_v2_renameItem] Error renaming item ${relativePath} to ${newName}:`, error);
+        return false;
+    }
+};

--- a/main/index.ts
+++ b/main/index.ts
@@ -7,13 +7,13 @@ import { SFTP_v1_listDirectory, SFTP_v1_downloadFile } from '../services/api/sft
 import { Launcher_v1_launchExternal } from '../services/api/launcher'
 import { AppStore_v1_discoverAvailableApps, AppStore_v1_installExternalApp } from '../services/api/appStore'
 import {
-  Filesystem_v1_getItemsInPath,
-  Filesystem_v1_createFolder,
-  Filesystem_v1_createFile,
-  Filesystem_v1_deleteItem,
-  Filesystem_v1_renameItem,
-  Filesystem_v1_readAppFile,
-} from '../services/api/filesystem'
+  Filesystem_v2_getItemsInPath,
+  Filesystem_v2_createFolder,
+  Filesystem_v2_createFile,
+  Filesystem_v2_deleteItem,
+  Filesystem_v2_renameItem,
+  Filesystem_v2_readAppFile,
+} from '../services/api/filesystem_v2'
 
 // The built directory structure
 //
@@ -126,12 +126,6 @@ app.whenReady().then(() => {
     return null; // Or return an error object
   });
 
-  // Ensure the virtual filesystem directory exists on startup
-  const virtualFsPath = path.join(process.cwd(), 'virtual-fs', 'Desktop');
-  if (!fs.existsSync(virtualFsPath)) {
-    fs.mkdirSync(virtualFsPath, { recursive: true });
-  }
-
   // Register IPC handlers for our new notebook functions
   ipcMain.handle('notebook:readFile', (_event, filePath: string) => {
     return Notebook_v1_readFile(filePath)
@@ -143,22 +137,22 @@ app.whenReady().then(() => {
 
   // Register IPC handlers for our new filesystem functions
   ipcMain.handle('fs:getItemsInPath', (_event, path: string) => {
-    return Filesystem_v1_getItemsInPath(path)
+    return Filesystem_v2_getItemsInPath(path)
   })
   ipcMain.handle('fs:createFolder', (_event, path: string, folderName: string) => {
-    return Filesystem_v1_createFolder(path, folderName)
+    return Filesystem_v2_createFolder(path, folderName)
   })
   ipcMain.handle('fs:createFile', (_event, path: string, fileName: string) => {
-    return Filesystem_v1_createFile(path, fileName)
+    return Filesystem_v2_createFile(path, fileName)
   })
   ipcMain.handle('fs:deleteItem', (_event, path: string) => {
-    return Filesystem_v1_deleteItem(path)
+    return Filesystem_v2_deleteItem(path)
   })
   ipcMain.handle('fs:renameItem', (_event, path: string, newName: string) => {
-    return Filesystem_v1_renameItem(path, newName)
+    return Filesystem_v2_renameItem(path, newName)
   })
   ipcMain.handle('fs:readAppFile', (_event, path: string) => {
-    return Filesystem_v1_readAppFile(path)
+    return Filesystem_v2_readAppFile(path)
   })
 
   // Register IPC handler for launching external apps

--- a/services/api/filesystem_v2.ts
+++ b/services/api/filesystem_v2.ts
@@ -1,0 +1,13 @@
+/**
+ * @file This file re-exports the stable filesystem v2 functions.
+ * It acts as a clean, logic-free interface to the core functionality.
+ */
+
+export {
+    Filesystem_v2_getItemsInPath,
+    Filesystem_v2_createFolder,
+    Filesystem_v2_createFile,
+    Filesystem_v2_deleteItem,
+    Filesystem_v2_renameItem,
+    Filesystem_v2_readAppFile,
+} from '../../function/stable/filesystem/Filesystem_v2_main';

--- a/window/src/apps/FileExplorer/FileExplorerApp.tsx
+++ b/window/src/apps/FileExplorer/FileExplorerApp.tsx
@@ -118,10 +118,10 @@ const FileExplorerApp: React.FC<AppComponentProps> = ({ setTitle, initialData })
     };
 
     const shortcuts = [
-        { name: 'Home', path: '/', icon: 'home' },
-        { name: 'Apps', path: '/apps', icon: 'appfolder' },
-        { name: 'Services', path: '/services', icon: 'appfolder' },
-        { name: 'Window', path: '/window', icon: 'appfolder' },
+        { name: 'Home', path: '/', icon: 'fileExplorer' },
+        { name: 'Apps', path: '/apps', icon: 'folder' },
+        { name: 'Services', path: '/services', icon: 'folder' },
+        { name: 'Window', path: '/window', icon: 'folder' },
     ];
 
     return (
@@ -136,7 +136,7 @@ const FileExplorerApp: React.FC<AppComponentProps> = ({ setTitle, initialData })
                 </button>
 
                 <div className="flex items-center bg-zinc-900 rounded p-1 text-sm flex-grow border border-zinc-700">
-                    <Icon iconName="home" className="w-4 h-4 mx-1" />
+                    <Icon iconName="fileExplorer" className="w-4 h-4 mx-1" />
                     <button onClick={() => navigateTo('/')} className="hover:underline">Home</button>
                     {breadcrumbParts.map((part, index) => (
                         <React.Fragment key={index}>

--- a/window/src/apps/FileExplorer/FileExplorerApp.tsx
+++ b/window/src/apps/FileExplorer/FileExplorerApp.tsx
@@ -19,7 +19,7 @@ const getFileIconName = (filename: string): string => {
 
 const FileExplorerApp: React.FC<AppComponentProps> = ({ setTitle, initialData }) => {
     const dispatch = useDispatch<AppDispatch>();
-    const startPath = initialData?.initialPath || '/Desktop';
+    const startPath = initialData?.initialPath || '/';
     const [currentPath, setCurrentPath] = useState(startPath);
     const [history, setHistory] = useState([startPath]);
     const [historyIndex, setHistoryIndex] = useState(0);
@@ -62,8 +62,8 @@ const FileExplorerApp: React.FC<AppComponentProps> = ({ setTitle, initialData })
     };
 
     const goUp = () => {
-        if (currentPath !== '/Desktop') {
-            const parentPath = currentPath.substring(0, currentPath.lastIndexOf('/')) || '/Desktop';
+        if (currentPath !== '/') {
+            const parentPath = currentPath.substring(0, currentPath.lastIndexOf('/')) || '/';
             navigateTo(parentPath);
         }
     };
@@ -110,72 +110,95 @@ const FileExplorerApp: React.FC<AppComponentProps> = ({ setTitle, initialData })
         ];
     };
 
-    const breadcrumbParts = currentPath.substring('/Desktop'.length).split('/').filter(p => p);
+    const breadcrumbParts = currentPath === '/' ? [] : currentPath.substring(1).split('/');
 
     const handleBreadcrumbClick = (index: number) => {
-        const newPath = '/Desktop' + (index > 0 ? '/' + breadcrumbParts.slice(0, index).join('/') : '');
+        const newPath = '/' + breadcrumbParts.slice(0, index + 1).join('/');
         navigateTo(newPath);
     };
+
+    const shortcuts = [
+        { name: 'Home', path: '/', icon: 'home' },
+        { name: 'Apps', path: '/apps', icon: 'appfolder' },
+        { name: 'Services', path: '/services', icon: 'appfolder' },
+        { name: 'Window', path: '/window', icon: 'appfolder' },
+    ];
 
     return (
         <div className="flex h-full bg-zinc-900 text-white select-none flex-col" onClick={() => { closeContextMenu(); if (renamingItem) handleRenameSubmit(); }}>
             {/* Toolbar */}
             <div className="flex-shrink-0 flex items-center space-x-1 p-2 border-b border-zinc-700 bg-zinc-800">
-                {/* Navigation Buttons */}
                 <button onClick={goBack} disabled={historyIndex === 0} className="p-1.5 rounded hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed">
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clipRule="evenodd" /></svg>
                 </button>
-                <button onClick={goUp} disabled={currentPath === '/Desktop'} className="p-1.5 rounded hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed">
+                <button onClick={goUp} disabled={currentPath === '/'} className="p-1.5 rounded hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed">
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M5.293 9.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L11 7.414V15a1 1 0 11-2 0V7.414L6.707 9.707a1 1 0 01-1.414 0z" clipRule="evenodd" /></svg>
                 </button>
 
-                {/* Breadcrumb / Address Bar */}
                 <div className="flex items-center bg-zinc-900 rounded p-1 text-sm flex-grow border border-zinc-700">
-                    <Icon iconName="desktop" className="w-4 h-4 mx-1" />
-                    <button onClick={() => navigateTo('/Desktop')} className="hover:underline">Desktop</button>
-                    {breadcrumbParts.length > 0 && <span className="mx-1 text-zinc-500">/</span>}
+                    <Icon iconName="home" className="w-4 h-4 mx-1" />
+                    <button onClick={() => navigateTo('/')} className="hover:underline">Home</button>
                     {breadcrumbParts.map((part, index) => (
                         <React.Fragment key={index}>
-                            <button onClick={() => handleBreadcrumbClick(index + 1)} className="hover:underline">{part}</button>
-                            {index < breadcrumbParts.length - 1 && <span className="mx-1 text-zinc-500">/</span>}
+                            <span className="mx-1 text-zinc-500">/</span>
+                            <button onClick={() => handleBreadcrumbClick(index)} className="hover:underline">{part}</button>
                         </React.Fragment>
                     ))}
                 </div>
 
-                 {/* Refresh Button */}
                  <button onClick={fetchItems} className="p-1.5 rounded hover:bg-zinc-700">
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h5M20 20v-5h-5M4 4l1.5 1.5A9 9 0 0120.5 15M20 20l-1.5-1.5A9 9 0 003.5 9" /></svg>
                 </button>
             </div>
-            {/* Main content */}
-            <main className="flex-grow flex flex-col">
-                <div className="flex-grow p-4 overflow-y-auto" onContextMenu={handleContextMenu}>
-                    {isLoading ? <p>Loading...</p> : (
-                        <div className="grid grid-cols-6 sm:grid-cols-8 md:grid-cols-10 lg:grid-cols-12 gap-4">
-                            {items.map(item => (
-                                <div key={item.path} onContextMenu={(e) => handleContextMenu(e, item)} onDoubleClick={() => openItem(item)} className="flex flex-col items-center p-2 rounded hover:bg-white/10 text-center">
-                                    <Icon iconName={item.type === 'folder' ? 'folder' : getFileIconName(item.name)} className="w-12 h-12" />
-                                    {renamingItem?.path === item.path ? (
-                                        <input
-                                            type="text"
-                                            value={renamingItem.value}
-                                            onChange={(e) => setRenamingItem({ ...renamingItem, value: e.target.value })}
-                                            onBlur={handleRenameSubmit}
-                                            onKeyDown={(e) => { if (e.key === 'Enter') handleRenameSubmit(); }}
-                                            className="text-xs text-center text-black bg-white w-full border border-blue-500 mt-1.5"
-                                            autoFocus
-                                            onFocus={e => e.target.select()}
-                                            onClick={e => e.stopPropagation()}
-                                        />
-                                    ) : (
-                                        <span className="text-xs mt-1.5 break-words w-full truncate">{item.name}</span>
-                                    )}
-                                </div>
+
+            <div className="flex flex-grow overflow-hidden">
+                {/* Left Navigation Pane */}
+                <aside className="w-48 bg-zinc-800/50 p-2 flex-shrink-0 overflow-y-auto">
+                    <nav>
+                        <ul>
+                            {shortcuts.map(shortcut => (
+                                <li key={shortcut.name}>
+                                    <button onClick={() => navigateTo(shortcut.path)} className={`w-full text-left flex items-center p-2 rounded my-1 ${currentPath === shortcut.path ? 'bg-blue-600' : 'hover:bg-zinc-700'}`}>
+                                        <Icon iconName={shortcut.icon} className="w-5 h-5 mr-2" />
+                                        <span>{shortcut.name}</span>
+                                    </button>
+                                </li>
                             ))}
-                        </div>
-                    )}
-                </div>
-            </main>
+                        </ul>
+                    </nav>
+                </aside>
+
+                {/* Main Content */}
+                <main className="flex-grow flex flex-col">
+                    <div className="flex-grow p-4 overflow-y-auto" onContextMenu={handleContextMenu}>
+                        {isLoading ? <p>Loading...</p> : (
+                            <div className="grid grid-cols-6 sm:grid-cols-8 md:grid-cols-10 lg:grid-cols-12 gap-4">
+                                {items.map(item => (
+                                    <div key={item.path} onContextMenu={(e) => handleContextMenu(e, item)} onDoubleClick={() => openItem(item)} className="flex flex-col items-center p-2 rounded hover:bg-white/10 text-center">
+                                        <Icon iconName={item.type === 'folder' ? 'folder' : getFileIconName(item.name)} className="w-12 h-12" />
+                                        {renamingItem?.path === item.path ? (
+                                            <input
+                                                type="text"
+                                                value={renamingItem.value}
+                                                onChange={(e) => setRenamingItem({ ...renamingItem, value: e.target.value })}
+                                                onBlur={handleRenameSubmit}
+                                                onKeyDown={(e) => { if (e.key === 'Enter') handleRenameSubmit(); }}
+                                                className="text-xs text-center text-black bg-white w-full border border-blue-500 mt-1.5"
+                                                autoFocus
+                                                onFocus={e => e.target.select()}
+                                                onClick={e => e.stopPropagation()}
+                                            />
+                                        ) : (
+                                            <span className="text-xs mt-1.5 break-words w-full truncate">{item.name}</span>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </main>
+            </div>
+
             {contextMenu && (
                 <ContextMenu x={contextMenu.x} y={contextMenu.y} items={generateContextMenuItems()} onClose={closeContextMenu} />
             )}


### PR DESCRIPTION
This commit implements a major overhaul of the File Explorer application based on user feedback. The virtual filesystem has been replaced with the real project filesystem, and the UI has been updated to include a navigation pane, aligning it more closely with modern file explorers like Windows 11's.

Major changes:

1.  **Real Filesystem Backend:**
    -   Abandoned the `virtual-fs` in favor of accessing the actual project directory.
    -   Created a new, versioned stable function (`Filesystem_v2`) to handle file operations. This follows the project's core principle of immutability for stable functions.
    -   The new `v2` function includes security checks to prevent path traversal attacks outside of the project's root directory.
    -   The main process has been updated to use this new `v2` service for all filesystem-related IPC calls.

2.  **Left Navigation Pane:**
    -   The File Explorer UI now features a two-column layout with a navigation sidebar on the left.
    -   The sidebar includes shortcuts to key project directories (Home, apps, services, window) for quick navigation.
    -   The selected shortcut is highlighted.

3.  **Updated Logic:**
    -   The component's internal logic, including the start path, breadcrumb navigation, and "up" button functionality, has been updated to work with the new project-root-based filesystem.