### PR TITLE
fix(icons): Correct icon names in app definitions

### DIFF
--- a/virtual-fs/Desktop/Hellow.app
+++ b/virtual-fs/Desktop/Hellow.app
@@ -1,5 +1,5 @@
 {
   "appId": "hellow",
   "name": "Hellow",
-  "icon": "hellow"
+  "icon": "chrome"
 }

--- a/virtual-fs/Desktop/Simple-node-app.app
+++ b/virtual-fs/Desktop/Simple-node-app.app
@@ -1,5 +1,5 @@
 {
   "appId": "simple-node-app",
   "name": "Simple-node-app",
-  "icon": "simple-node-app"
+  "icon": "chrome"
 }

--- a/window/src/apps/HellowApp.tsx
+++ b/window/src/apps/HellowApp.tsx
@@ -12,7 +12,7 @@ const LauncherComponent: React.FC<AppComponentProps> = () => {
 export const appDefinition: AppDefinition = {
   "id": "hellow",
   "name": "Hellow",
-  "icon": "hellow",
+  "icon": "chrome",
   "isExternal": true,
   "externalPath": "apps\\hellow\\main.js",
   "component": null

--- a/window/src/apps/Simple-node-appApp.tsx
+++ b/window/src/apps/Simple-node-appApp.tsx
@@ -12,7 +12,7 @@ const LauncherComponent: React.FC<AppComponentProps> = () => {
 export const appDefinition: AppDefinition = {
   "id": "simple-node-app",
   "name": "Simple-node-app",
-  "icon": "simple-node-app",
+  "icon": "chrome",
   "isExternal": true,
   "externalPath": "apps\\simple-node-app\\main.js",
   "component": null


### PR DESCRIPTION
This commit fixes a bug that caused "Icon not found" errors for the 'hellow' and 'simple-node-app' applications.

The root cause was that the application definitions, both in the `.app` files on the virtual desktop and in their corresponding `.tsx` files, were specifying their own names as their icons. These icon names were not registered in the central `iconMap` in the `Icon.tsx` component.

This fix replaces the invalid icon names with 'chrome', a valid icon from the `iconMap` that can serve as a generic placeholder for external applications.

The following files were modified:
- `virtual-fs/Desktop/Hellow.app`
- `virtual-fs/Desktop/Simple-node-app.app`
- `window/src/apps/HellowApp.tsx`
- `window/src/apps/Simple-node-appApp.tsx`

This change prevents the console errors and allows the application icons to be rendered correctly.