### PR TITLE
fix(filesystem): Correct path resolution logic

### DIFF
--- a/function/stable/filesystem/Filesystem_v2_main.ts
+++ b/function/stable/filesystem/Filesystem_v2_main.ts
@@ -10,7 +10,11 @@ const PROJECT_ROOT = process.cwd();
  * @returns The resolved, absolute path if it's safe, or null otherwise.
  */
 const resolveSafePath = (relativePath: string): string | null => {
-    const fullPath = path.resolve(PROJECT_ROOT, relativePath);
+    // First, join the path to handle relative paths correctly.
+    // Then, resolve the path to canonicalize it (e.g., remove '..').
+    const fullPath = path.resolve(path.join(PROJECT_ROOT, relativePath));
+
+    // Finally, check if the canonicalized path is still within the project root.
     if (!fullPath.startsWith(PROJECT_ROOT)) {
         console.error(`[Security] Path traversal attempt blocked: ${relativePath}`);
         return null;


### PR DESCRIPTION
This commit fixes a critical bug in the `resolveSafePath` helper function within the `Filesystem_v2_main.ts` stable function.

The previous implementation incorrectly used `path.resolve(PROJECT_ROOT, relativePath)`. When `relativePath` was an absolute path (e.g., '/Desktop'), `path.resolve` would treat it as the new root, causing the subsequent security check (`fullPath.startsWith(PROJECT_ROOT)`) to fail for all valid paths. This effectively blocked all filesystem operations.

The fix changes the implementation to `path.resolve(path.join(PROJECT_ROOT, relativePath))`. This correctly joins the project root with the relative path first, and then canonicalizes the result. This ensures that valid paths within the project are resolved correctly while still preventing path traversal attacks.