### PR TITLE
feat(ui): Implement context menu system

### DIFF
--- a/window/src/apps/FileExplorer/FileExplorerApp.tsx
+++ b/window/src/apps/FileExplorer/FileExplorerApp.tsx
@@ -100,6 +100,8 @@ const FileExplorerApp: React.FC<AppComponentProps> = ({ setTitle, initialData })
                 { type: 'separator' },
                 { type: 'item', label: 'Delete', onClick: async () => { if (await window.electronAPI.filesystem.deleteItem(item.path)) fetchItems(); } },
                 { type: 'item', label: 'Rename', onClick: () => setRenamingItem({ path: item.path, value: item.name }) },
+                { type: 'separator' },
+                { type: 'item', label: 'Properties', onClick: () => {}, disabled: true },
             ];
         }
         return [

--- a/window/src/components/layout/Desktop.tsx
+++ b/window/src/components/layout/Desktop.tsx
@@ -141,6 +141,7 @@ const Desktop: React.FC = () => {
             { type: 'item', label: 'New Text File', onClick: async () => { let n = 'New Text File.txt', i = 0; while (desktopItems.some(item => item.name === n)) n = `New Text File (${++i}).txt`; if (await window.electronAPI.filesystem.createFile('/Desktop', n)) fetchDesktopItems(); } },
             { type: 'separator' },
             { type: 'item', label: 'Refresh', onClick: fetchDesktopItems },
+            { type: 'item', label: 'Properties', onClick: () => {}, disabled: true },
         ];
     };
 

--- a/window/src/components/layout/Taskbar.tsx
+++ b/window/src/components/layout/Taskbar.tsx
@@ -6,6 +6,7 @@ import { _openInternalApp, focusApp, toggleMinimizeApp } from '../../store/slice
 import { getAppDefinitions, getAppDefinitionById } from '../../apps';
 import Icon from '../features/Icon';
 import { AppDefinition, OpenApp } from '../../types';
+import ContextMenu, { ContextMenuItem } from '../features/ContextMenu';
 
 const TASKBAR_HEIGHT = 48;
 
@@ -20,6 +21,7 @@ const Taskbar: React.FC = () => {
     const { pinnedApps } = useSelector((state: RootState) => state.ui);
     const [currentTime, setCurrentTime] = useState(new Date());
     const [allApps, setAllApps] = useState<AppDefinition[]>([]);
+    const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
 
     useEffect(() => {
         const timerId = setInterval(() => setCurrentTime(new Date()), 1000);
@@ -88,10 +90,26 @@ const Taskbar: React.FC = () => {
         }
     };
 
+    const closeContextMenu = () => setContextMenu(null);
+
+    const handleContextMenu = (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setContextMenu({ x: e.clientX, y: e.clientY });
+    };
+
+    const generateContextMenuItems = (): ContextMenuItem[] => {
+        return [
+            { type: 'item', label: 'Taskbar settings', onClick: () => { console.log("Taskbar settings clicked") }, disabled: true },
+        ];
+    };
+
     return (
         <div
             className="fixed bottom-0 left-0 right-0 bg-gray-800 bg-opacity-80 backdrop-blur-md text-white flex items-center justify-between px-4"
             style={{ height: `${TASKBAR_HEIGHT}px` }}
+            onContextMenu={handleContextMenu}
+            onClick={closeContextMenu}
         >
             <div className="flex-1 flex justify-center items-center h-full">
                 <div className="flex items-center space-x-2 h-full">
@@ -124,6 +142,10 @@ const Taskbar: React.FC = () => {
                 <div>{currentTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</div>
                 <div>{currentTime.toLocaleDateString([], { month: 'short', day: 'numeric' })}</div>
             </div>
+
+            {contextMenu && (
+                <ContextMenu x={contextMenu.x} y={contextMenu.y} items={generateContextMenuItems()} onClose={closeContextMenu} />
+            )}
         </div>
     );
 };


### PR DESCRIPTION
This commit implements a right-click context menu system across the application to better align with the UI/UX of Windows 11.

Context menus have been added or enhanced in the following areas:

1.  **Desktop:**
    -   A context menu is now available when right-clicking on the desktop background.
    -   Options include "New Folder", "New Text File", "Refresh", and a disabled "Properties" placeholder.

2.  **Taskbar:**
    -   The taskbar now has a context menu when right-clicked.
    -   It contains a disabled "Taskbar settings" placeholder.

3.  **File Explorer:**
    -   The existing context menu for files has been enhanced with a disabled "Properties" placeholder.

This feature uses a generic `ContextMenu` component, which has been applied consistently across the different parts of the UI.