### PR TITLE
fix(ui): Fix taskbar context menu and startup crash

### DIFF
--- a/window/src/components/layout/Taskbar.tsx
+++ b/window/src/components/layout/Taskbar.tsx
@@ -93,14 +93,12 @@ const Taskbar: React.FC = () => {
     const closeContextMenu = () => setContextMenu(null);
 
     const handleContextMenu = (e: React.MouseEvent, app?: TaskbarApp) => {
-        console.log('[DEBUG] handleContextMenu called. App:', app ? app.name : 'N/A');
         e.preventDefault();
         e.stopPropagation();
         setContextMenu({ x: e.clientX, y: e.clientY, targetApp: app });
     };
 
     const generateContextMenuItems = (): ContextMenuItem[] => {
-        console.log('[DEBUG] generateContextMenuItems called. Target App:', contextMenu?.targetApp?.name);
         const app = contextMenu?.targetApp;
         if (app) {
             const isPinned = pinnedApps.includes(app.id);
@@ -108,7 +106,6 @@ const Taskbar: React.FC = () => {
 
             const menuItems: ContextMenuItem[] = [];
 
-            // Add app name as a title item if possible (or just a disabled item)
             menuItems.push({ type: 'item', label: app.name, disabled: true, onClick: () => {} });
             menuItems.push({ type: 'separator' });
 
@@ -146,7 +143,7 @@ const Taskbar: React.FC = () => {
             className="fixed bottom-0 left-0 right-0 bg-gray-800 bg-opacity-80 backdrop-blur-md text-white flex items-center justify-between px-4"
             style={{ height: `${TASKBAR_HEIGHT}px` }}
             onContextMenu={(e) => handleContextMenu(e)}
-            onClick={closeContextMenu}
+            onClick={(e) => { if (e.button === 0) closeContextMenu(); }}
         >
             <div className="flex-1 flex justify-center items-center h-full">
                 <div className="flex items-center space-x-2 h-full">
@@ -160,10 +157,7 @@ const Taskbar: React.FC = () => {
                             <button
                                 key={buttonKey}
                                 onClick={() => handleAppIconClick(app)}
-                                onContextMenu={(e) => {
-                                    console.log(`[DEBUG] onContextMenu event fired for app: ${app.name}`);
-                                    handleContextMenu(e, app);
-                                }}
+                                onContextMenu={(e) => handleContextMenu(e, app)}
                                 className={`p-2 rounded h-[calc(100%-8px)] flex items-center relative transition-colors duration-150 ease-in-out ${app.isActive ? 'bg-white/20' : 'hover:bg-white/10'}`}
                                 title={app.name}
                             >


### PR DESCRIPTION
This commit addresses two issues that were making the UI unresponsive and preventing the taskbar context menu from appearing.

1.  **Startup Error:** A missing `/Desktop` directory was causing an `ENOENT` error on startup, which halted rendering for key components. This commit adds the empty `Desktop` directory to resolve this crash.

2.  **Taskbar Context Menu Bug:** The context menu was not appearing due to a race condition between the `onContextMenu` and `onClick` events. The `onClick` handler on the taskbar has been modified to only fire on left-clicks, preventing it from immediately closing the context menu opened by a right-click.