### PR TITLE
debug(taskbar): Add advanced logging to diagnose context menu bug

### DIFF
--- a/window/src/components/layout/Taskbar.tsx
+++ b/window/src/components/layout/Taskbar.tsx
@@ -24,6 +24,10 @@ const Taskbar: React.FC = () => {
     const [contextMenu, setContextMenu] = useState<{ x: number; y: number; targetApp?: TaskbarApp } | null>(null);
 
     useEffect(() => {
+        console.log('[DEBUG] contextMenu state changed:', contextMenu);
+    }, [contextMenu]);
+
+    useEffect(() => {
         const timerId = setInterval(() => setCurrentTime(new Date()), 1000);
         return () => clearInterval(timerId);
     }, []);
@@ -178,9 +182,10 @@ const Taskbar: React.FC = () => {
                 <div>{currentTime.toLocaleDateString([], { month: 'short', day: 'numeric' })}</div>
             </div>
 
-            {contextMenu && (
-                <ContextMenu x={contextMenu.x} y={contextMenu.y} items={generateContextMenuItems()} onClose={closeContextMenu} />
-            )}
+            {contextMenu && (() => {
+                console.log('[DEBUG] Rendering ContextMenu with items:', generateContextMenuItems());
+                return <ContextMenu x={contextMenu.x} y={contextMenu.y} items={generateContextMenuItems()} onClose={closeContextMenu} />
+            })()}
         </div>
     );
 };


### PR DESCRIPTION
This commit adds more detailed `console.log` statements to the Taskbar.tsx component to help diagnose a persistent issue where the context menu for app icons is not appearing.

The new logging includes:
- A `useEffect` hook that logs the `contextMenu` state whenever it changes.
- A log statement immediately before the `<ContextMenu />` component is rendered to inspect the props being passed to it.

This will help determine if the component state is being set correctly and if the menu is being rendered.