### PR TITLE
fix(taskbar): Refine click handlers to prevent context menu conflict

### DIFF
--- a/window/src/components/layout/Taskbar.tsx
+++ b/window/src/components/layout/Taskbar.tsx
@@ -143,9 +143,8 @@ const Taskbar: React.FC = () => {
             className="fixed bottom-0 left-0 right-0 bg-gray-800 bg-opacity-80 backdrop-blur-md text-white flex items-center justify-between px-4"
             style={{ height: `${TASKBAR_HEIGHT}px` }}
             onContextMenu={(e) => handleContextMenu(e)}
-            onClick={(e) => { if (e.button === 0) closeContextMenu(); }}
         >
-            <div className="flex-1 flex justify-center items-center h-full">
+            <div className="flex-1 flex justify-center items-center h-full" onClick={closeContextMenu}>
                 <div className="flex items-center space-x-2 h-full">
                     <button onClick={handleToggleStartMenu} className="p-2 rounded hover:bg-white/20" title="Start">
                         <Icon iconName="start" className="w-6 h-6 text-blue-400" />


### PR DESCRIPTION
This commit attempts to fix a persistent bug where the taskbar icon context menu does not appear.

The theory is that the `onClick` handler on the main taskbar `div` was interfering with the `onContextMenu` event of its children.

This fix moves the `onClick` handler for closing the menu to a more specific inner `div` that represents the empty space on the taskbar. This should prevent the handler from capturing events from the app icons, which should allow the context menu to appear correctly.