### PR TITLE
fix(ui): Fix context menu event listener conflict

### DIFF
--- a/window/src/components/features/ContextMenu.tsx
+++ b/window/src/components/features/ContextMenu.tsx
@@ -80,8 +80,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ x, y, items, onClose, isSubMe
               onClose();
           }
       };
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
+      document.addEventListener('click', handleClickOutside, true); // Use capture phase
+      return () => document.removeEventListener('click', handleClickOutside, true);
   }, [onClose, isSubMenu]);
 
   // Adjust position to stay within viewport

--- a/window/src/components/layout/Taskbar.tsx
+++ b/window/src/components/layout/Taskbar.tsx
@@ -143,8 +143,9 @@ const Taskbar: React.FC = () => {
             className="fixed bottom-0 left-0 right-0 bg-gray-800 bg-opacity-80 backdrop-blur-md text-white flex items-center justify-between px-4"
             style={{ height: `${TASKBAR_HEIGHT}px` }}
             onContextMenu={(e) => handleContextMenu(e)}
+            onClick={closeContextMenu}
         >
-            <div className="flex-1 flex justify-center items-center h-full" onClick={closeContextMenu}>
+            <div className="flex-1 flex justify-center items-center h-full">
                 <div className="flex items-center space-x-2 h-full">
                     <button onClick={handleToggleStartMenu} className="p-2 rounded hover:bg-white/20" title="Start">
                         <Icon iconName="start" className="w-6 h-6 text-blue-400" />


### PR DESCRIPTION
This commit fixes a persistent bug where the context menus would not appear when right-clicking on taskbar icons.

The root cause was identified in the `ContextMenu.tsx` component itself. It was using a `mousedown` event listener to detect outside clicks. This listener was firing on the `mousedown` of the right-click that was intended to open the menu, causing the menu to be closed the instant it was created.

The fix changes the event listener from `mousedown` to `click` and sets it to use the capture phase. A standard `click` event is not fired on a right-click, so this robustly prevents the conflict.

This commit also reverts the `Taskbar.tsx` component to its simpler, original state, as the workarounds were no longer needed with this fundamental fix.