### PR TITLE
debug(taskbar): Use onMouseDown for context menu debugging

### DIFF
--- a/window/src/components/layout/Taskbar.tsx
+++ b/window/src/components/layout/Taskbar.tsx
@@ -157,7 +157,13 @@ const Taskbar: React.FC = () => {
                             <button
                                 key={buttonKey}
                                 onClick={() => handleAppIconClick(app)}
-                                onContextMenu={(e) => handleContextMenu(e, app)}
+                                onMouseDown={(e) => {
+                                    if (e.button === 2) {
+                                        console.log(`[DEBUG] Right mouse down on app: ${app.name}`);
+                                        handleContextMenu(e, app);
+                                    }
+                                }}
+                                onContextMenu={(e) => e.preventDefault()} // Prevent native menu
                                 className={`p-2 rounded h-[calc(100%-8px)] flex items-center relative transition-colors duration-150 ease-in-out ${app.isActive ? 'bg-white/20' : 'hover:bg-white/10'}`}
                                 title={app.name}
                             >


### PR DESCRIPTION
This commit replaces the `onContextMenu` event handler on the taskbar app icons with a more primitive `onMouseDown` handler.

This is a diagnostic step to definitively determine if the buttons are receiving mouse events correctly. The handler checks if the right mouse button (`e.button === 2`) was pressed and logs a message if it was.

This will help debug a persistent issue where the context menu is not appearing on right-click.